### PR TITLE
Add Sandbox exceptions to export to Ryujinx

### DIFF
--- a/io.github.randovania.Randovania.yml
+++ b/io.github.randovania.Randovania.yml
@@ -11,7 +11,7 @@ finish-args:
     - --socket=fallback-x11
     # For Ryujinx/Dread exporting
     - --filesystem=~/.var/app/org.ryujinx.Ryujinx/config/Ryujinx    # Ryujinx flatpak
-    - --filesystem=xdg-config/Ryujinx
+    - --filesystem=xdg-config/Ryujinx                               # Ryujinx native
 command: /app/bin/randovania
 modules:
   - name: randovania

--- a/io.github.randovania.Randovania.yml
+++ b/io.github.randovania.Randovania.yml
@@ -9,6 +9,9 @@ finish-args:
     - --share=ipc           # Needed for X11 support
     - --socket=wayland
     - --socket=fallback-x11
+    # For Ryujinx/Dread exporting
+    - --filesystem=~/.var/app/org.ryujinx.Ryujinx/config/Ryujinx    # Ryujinx flatpak
+    - --filesystem=xdg-config/Ryujinx
 command: /app/bin/randovania
 modules:
   - name: randovania


### PR DESCRIPTION
Using `xdg-config/Ryujinx` *should* hopefully be enough for me to not need any changes in the other PR